### PR TITLE
fix(properties): correctly handle unknown property get

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -45,12 +45,13 @@ Properties.prototype.set = function(target, name, value) {
  */
 Properties.prototype.get = function(target, name) {
 
-  var property = this.model.getPropertyDescriptor(target, name),
-      propertyName = property.name;
+  var property = this.model.getPropertyDescriptor(target, name);
 
   if (!property) {
-    return target[name];
+    return target.$attrs[name];
   }
+
+  var propertyName = property.name;
 
   // check if access to collection property and lazily initialize it
   if (!target[propertyName] && property.isMany) {

--- a/test/spec/moddleSpec.js
+++ b/test/spec/moddleSpec.js
@@ -429,6 +429,21 @@ describe('Moddle', function() {
         });
 
 
+        it('should return $attrs property on non-metamodel defined property access', function() {
+
+          // given
+          var BaseWithNumericId = model.getType('props:BaseWithNumericId');
+
+          // when
+          var instance = new BaseWithNumericId({ 'id': 1000 });
+
+          instance.$attrs.unknown = 'UNKNOWN';
+
+          // then
+          expect(instance.get('unknown')).toEqual('UNKNOWN');
+        });
+
+
         it('access via original name', function() {
 
           // given


### PR DESCRIPTION
When parsing invalid documents with [moddle-xml](https://github.com/bpmn-io/moddle-xml) the user occasionally sees

```
"Uncaught TypeError: Cannot read property 'name' of undefined" for Properties.prototype.get
```

This is due to the fact that we did not correctly handle unknown properties in `ModdleElement#get`.

This pull request fixes the behavior.
