### PR TITLE
fix(properties): allow deletion of properties

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -30,6 +30,7 @@ Properties.prototype.set = function(target, name, value) {
     Object.defineProperty(target, property.name, {
       enumerable: !property.isReference,
       writable: true,
+      configurable: true,
       value: value
     });
   }
@@ -58,6 +59,7 @@ Properties.prototype.get = function(target, name) {
     Object.defineProperty(target, propertyName, {
       enumerable: !property.isReference,
       writable: true,
+      configurable: true,
       value: []
     });
   }

--- a/test/spec/moddle.js
+++ b/test/spec/moddle.js
@@ -351,6 +351,18 @@ describe('moddle', function() {
         expect(instance.id).to.equal('ATTR_1');
       });
 
+      it('should delete existing properties', function() {
+
+        // given
+        var attributes = model.create('props:Attributes', { id: 'ATTR_1' });
+
+        // when
+        delete attributes.id;
+
+        // then
+        expect(attributes.id).to.not.be.defined;
+      });
+
 
       it('should set single property (ns)', function() {
 


### PR DESCRIPTION
Properties have to be defined as configurable in order to be able to delete them.