### PR TITLE
Type Checks Added

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -126,7 +126,12 @@ Properties.prototype.checkValue = function(property, value) {
     return Types.checkBuiltInType(property.type, value);
   }
 
-  return value instanceof Base && this.model.getType(value.$type).hasType(property.type);
+  if (property.type in this.model.registry.typeMap) {
+    return value instanceof Base && this.model.getType(value.$type).hasType(property.type);
+  } else { // property.type in this.model.registry.enumerationMap
+    var enumeration = this.model.registry.enumerationMap[property.type];
+    return value in enumeration.literalValuesByName;
+  }
 };
 
 function isUndefined(val) {

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -122,10 +122,6 @@ Properties.prototype.checkValue = function(property, value) {
     }, true, this);
   }
 
-  if (property.isReference) {
-    return true;
-  }
-
   if (Types.isBuiltIn(property.type)) {
     return Types.checkBuiltInType(property.type, value);
   }

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -1,5 +1,11 @@
 'use strict';
 
+var reduce = require('lodash/collection/reduce'),
+    assign = require('lodash/object/assign');
+
+var Types = require('./types'),
+    Base = require('./base');
+
 
 /**
  * A utility that gets and sets properties of model elements.
@@ -39,6 +45,11 @@ Properties.prototype.set = function(target, name, value) {
     // set the property, defining well defined properties on the fly
     // or simply updating them in target.$attrs (for extensions)
     if (property) {
+      if (!this.checkValue(property, value)) {
+        throw new Error(
+          'Value \'' + value + '\' is/are not of type <' + property.type + '>'
+        );
+      }
       if (propertyName in target) {
         target[propertyName] = value;
       } else {
@@ -103,6 +114,24 @@ Properties.prototype.defineModel = function(target, model) {
   this.define(target, '$model', { value: model });
 };
 
+Properties.prototype.checkValue = function(property, value) {
+  if (property.isMany) {
+    var p = assign({}, property, { isMany: false });
+    return reduce(value, function(result, v) {
+      return result && this.checkValue(p, v);
+    }, true, this);
+  }
+
+  if (property.isReference) {
+    return true;
+  }
+
+  if (Types.isBuiltIn(property.type)) {
+    return Types.checkBuiltInType(property.type, value);
+  }
+
+  return value instanceof Base && this.model.getType(value.$type).hasType(property.type);
+};
 
 function isUndefined(val) {
   return typeof val === 'undefined';

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -14,6 +14,7 @@ var parseNameNs = require('./ns').parseName,
 function Registry(packages, properties) {
   this.packageMap = {};
   this.typeMap = {};
+  this.enumerationMap = {};
 
   this.packages = [];
 
@@ -48,6 +49,10 @@ Registry.prototype.registerPackage = function(pkg) {
   // register types
   forEach(pkg.types, function(descriptor) {
     this.registerType(descriptor, pkg);
+  }, this);
+
+  forEach(pkg.enumerations, function(descriptor) {
+    this.registerEnumeration(descriptor, pkg);
   }, this);
 
   this.packageMap[pkg.uri] = this.packageMap[pkg.prefix] = pkg;
@@ -85,7 +90,8 @@ Registry.prototype.registerType = function(type, pkg) {
       p.type = parseNameNs(p.type, propertyNs.prefix).name;
 
       var type = this.typeMap[p.type];
-      if (!type && name !== p.type) {
+      var enumeration = this.enumerationMap[p.type];
+      if (!type && !enumeration && name !== p.type) {
         this.unresolvedProperties[p.type] = p;
       }
     }
@@ -117,6 +123,34 @@ Registry.prototype.registerType = function(type, pkg) {
 
   // register
   this.typeMap[name] = type;
+};
+
+
+Registry.prototype.registerEnumeration = function(enumeration, pkg) {
+
+  enumeration = assign({}, enumeration, {
+    literalValues: (enumeration.literalValues || []).slice()
+  });
+
+  var ns = parseNameNs(enumeration.name, pkg.prefix),
+      name = ns.name;
+
+  delete this.unresolvedProperties[name];
+
+  var literalValuesByName = {};
+  forEach(enumeration.literalValues, function(value) {
+    literalValuesByName[value.name] = value;
+  });
+
+  assign(enumeration, {
+    ns: ns,
+    name: name,
+    literalValuesByName: literalValuesByName
+  });
+
+  this.definePackage(enumeration, pkg);
+
+  this.enumerationMap[name] = enumeration;
 };
 
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assign = require('lodash/object/assign'),
+    keys = require('lodash/object/keys'),
     forEach = require('lodash/collection/forEach');
 
 var Types = require('./types'),
@@ -17,8 +18,14 @@ function Registry(packages, properties) {
   this.packages = [];
 
   this.properties = properties;
+  this.unresolvedProperties = {};
 
   forEach(packages, this.registerPackage, this);
+
+  var unresolvedKeys = keys(this.unresolvedProperties);
+  if (unresolvedKeys.length > 0) {
+    throw new Error('At least one property type could not be resolved (<' + keys[0] + '>)');
+  }
 }
 
 module.exports = Registry;
@@ -64,6 +71,8 @@ Registry.prototype.registerType = function(type, pkg) {
       name = ns.name,
       propertiesByName = {};
 
+  delete this.unresolvedProperties[ns.name];
+
   // parse properties
   forEach(type.properties, function(p) {
 
@@ -74,6 +83,11 @@ Registry.prototype.registerType = function(type, pkg) {
     // namespace property types
     if (!isBuiltInType(p.type)) {
       p.type = parseNameNs(p.type, propertyNs.prefix).name;
+
+      var type = this.typeMap[p.type];
+      if (!type) {
+        this.unresolvedProperties[p.type] = p;
+      }
     }
 
     assign(p, {
@@ -82,7 +96,7 @@ Registry.prototype.registerType = function(type, pkg) {
     });
 
     propertiesByName[propertyName] = p;
-  });
+  }, this);
 
   // update ns + name
   assign(type, {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -85,7 +85,7 @@ Registry.prototype.registerType = function(type, pkg) {
       p.type = parseNameNs(p.type, propertyNs.prefix).name;
 
       var type = this.typeMap[p.type];
-      if (!type) {
+      if (!type && name !== p.type) {
         this.unresolvedProperties[p.type] = p;
       }
     }

--- a/lib/types.js
+++ b/lib/types.js
@@ -24,7 +24,7 @@ var TYPE_CONVERTERS = {
 var TYPE_CHECKERS = {
   String: function(s) { return typeof s === 'string'; },
   Boolean: function(b) { return typeof b === 'boolean'; },
-  Integer: function(i) { return Number.isInteger(i); },
+  Integer: function(i) { return typeof i === 'number' && i % 1 === 0; },
   Real: function(r) { return typeof r === 'number'; },
   Element: function(e) { return true; }
 };

--- a/lib/types.js
+++ b/lib/types.js
@@ -27,7 +27,7 @@ var TYPE_CHECKERS = {
   Integer: function(i) { return Number.isInteger(i); },
   Real: function(r) { return typeof r === 'number'; },
   Element: function(e) { return true; }
-}
+};
 
 /**
  * Convert a type to its real representation
@@ -45,7 +45,7 @@ module.exports.coerceType = function(type, value) {
 
 module.exports.checkBuiltInType = function(type, value) {
   return TYPE_CHECKERS[type](value);
-}
+};
 
 /**
  * Return whether the given type is built-in

--- a/lib/types.js
+++ b/lib/types.js
@@ -21,6 +21,14 @@ var TYPE_CONVERTERS = {
   Real: function(s) { return parseFloat(s, 10); }
 };
 
+var TYPE_CHECKERS = {
+  String: function(s) { return typeof s === 'string'; },
+  Boolean: function(b) { return typeof b === 'boolean'; },
+  Integer: function(i) { return Number.isInteger(i); },
+  Real: function(r) { return typeof r === 'number'; },
+  Element: function(e) { return true; }
+}
+
 /**
  * Convert a type to its real representation
  */
@@ -34,6 +42,10 @@ module.exports.coerceType = function(type, value) {
     return value;
   }
 };
+
+module.exports.checkBuiltInType = function(type, value) {
+  return TYPE_CHECKERS[type](value);
+}
 
 /**
  * Return whether the given type is built-in

--- a/test/fixtures/model/enumerations.json
+++ b/test/fixtures/model/enumerations.json
@@ -1,0 +1,35 @@
+{
+  "name": "Enumerations",
+  "uri": "http://enumerations",
+  "prefix": "enu",
+  "types": [
+    {
+      "name": "ColoredThing",
+      "properties": [
+        { "name": "color", "type": "Color" }
+      ]
+    },
+    {
+      "name": "MultiColoredThing",
+      "properties": [
+        { "name": "colors", "type": "Color", "isMany": true }
+      ]
+    }
+  ],
+  "enumerations": [
+    {
+      "name": "Color",
+      "literalValues": [
+        {
+          "name": "Yellow"
+        },
+        {
+          "name": "Red"
+        },
+        {
+          "name": "Blue"
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/model/properties.json
+++ b/test/fixtures/model/properties.json
@@ -81,7 +81,7 @@
       "name": "BaseWithNumericId",
       "superClass": [ "BaseWithId" ],
       "properties": [
-        { "name": "idNumeric", "type": "String", "isAttr": true, "redefines": "BaseWithId#id", "isId": true }
+        { "name": "idNumeric", "type": "Integer", "isAttr": true, "redefines": "BaseWithId#id", "isId": true }
       ]
     },
     {

--- a/test/spec/enumerations.js
+++ b/test/spec/enumerations.js
@@ -27,7 +27,7 @@ describe('enumerations', function() {
   });
 
   it('should reject unlisted values', function() {
-    expect(() => {model.create('enu:ColoredThing', { color: 'Striped' })})
+    expect(function() {model.create('enu:ColoredThing', { color: 'Striped' })})
       .to.throw(Error);
   });
 

--- a/test/spec/enumerations.js
+++ b/test/spec/enumerations.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var Helper = require('../helper');
+
+
+describe('enumerations', function() {
+
+  var createModel = Helper.createModelBuilder('test/fixtures/model/');
+  var model = createModel([ 'enumerations' ]);
+
+  it('should accept allowed values', function() {
+
+    var yellow = 'Yellow',
+        blue = 'Blue',
+        red = 'Red',
+        colors = [ yellow, blue, red ];
+
+    var yellowColoredThing = model.create('enu:ColoredThing', {
+      color: yellow
+    });
+    expect(yellowColoredThing.color).to.equal(yellow);
+
+    var multiColoredThing = model.create('enu:MultiColoredThing', {
+      colors: colors
+    });
+    expect(multiColoredThing.colors).to.equal(colors);
+  });
+
+  it('should reject unlisted values', function() {
+    expect(() => {model.create('enu:ColoredThing', { color: 'Striped' })})
+      .to.throw(Error);
+  });
+
+});


### PR DESCRIPTION
Adds two layers of type-checks to the package:

1. When all packages are registered on start-up, each property type is checked to be a registered type/enumeration or built-in. _See: [`lib/registry.js`](https://github.com/bpmn-io/moddle/compare/master...felixlinker:type-checks?expand=1#diff-bfd23b790da400f4bfbb0e467be85d52)._
2. Everytime `Base#set` respectively `Properties#set` is called, the value provided gets type-checked in `O(n)` with `n` being the number of values provided, i. e. `n = 3` for `x.set([ 1, 2, 3 ]) `. _See: [`lib/properties.js`](https://github.com/bpmn-io/moddle/compare/master...felixlinker:type-checks?expand=1#diff-327455fa29663c58312adf5955056773)._

_Warning_: I'm not sure whether I dealt correctly with referencing properties. I type-check them as if they were non-referencing properties which could lead to an error when adding the id (not the actual element) to the property. In this case, I'd reject the value.
For example, consider the type `<x:A>` with the property `<id>` of type `String` and the type `<x:B>` with the reference property `<a>` of type `<x:A>`. In my implementation, following code *would* result in an error:
```javascript
let a = moddle.create('x:A', { 'id': 'theid' });
let b = moddle.create('x:B', { 'a': 'theid' });
```
Whereas follwing code *would not* result in an error:
```javascript
let a = moddle.create('x:A', { 'id': 'theid' });
let b = moddle.create('x:B', { 'a': a });
```