### PR TITLE
Property Constraints Added

### DIFF
--- a/lib/factory.js
+++ b/lib/factory.js
@@ -51,6 +51,19 @@ Factory.prototype.createType = function(descriptor) {
     return !requiredNotSet;
   }
 
+  prototype.setUniquelyRequired = function() {
+    var typeDescriptor = model.getElementDescriptor(model.getType(this.$type));
+
+    forEach(typeDescriptor.propertiesByName, function(property, name) {
+      if (property.isRequired && property.constraint && property.constraint.enum) {
+        var enumerated = property.constraint.enum;
+        if (enumerated.length == 1) {
+          this.set(name, enumerated[0]);
+        }
+      }
+    }, this);
+  }
+
   var name = descriptor.ns.name;
 
   /**

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -40,7 +40,7 @@ Factory.prototype.createType = function(descriptor) {
       if (property.isRequired) {
         var val = this.get(name);
         if (property.isMany) {
-          requiredNotSet = size(val) == 0;
+          requiredNotSet = size(val) === 0;
         } else {
           requiredNotSet = isUndefined(val);
         }

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var forEach = require('lodash/collection/forEach');
+var forEach = require('lodash/collection/forEach'),
+    isUndefined = require('lodash/lang/isUndefined'),
+    size = require('lodash/collection/size');
 
 var Base = require('./base');
 
@@ -29,6 +31,25 @@ Factory.prototype.createType = function(descriptor) {
 
   props.defineModel(prototype, model);
   props.defineDescriptor(prototype, descriptor);
+
+  prototype.isValid = function() {
+    var typeDescriptor = model.getElementDescriptor(model.getType(this.$type));
+
+    var requiredNotSet = false;
+    forEach(typeDescriptor.propertiesByName, function(property, name) {
+      if (property.isRequired) {
+        var val = this.get(name);
+        if (property.isMany) {
+          requiredNotSet = size(val) == 0;
+        } else {
+          requiredNotSet = isUndefined(val);
+        }
+        return !requiredNotSet;
+      }
+    }, this);
+
+    return !requiredNotSet;
+  }
 
   var name = descriptor.ns.name;
 

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -49,7 +49,7 @@ Factory.prototype.createType = function(descriptor) {
     }, this);
 
     return !requiredNotSet;
-  }
+  };
 
   prototype.setUniquelyRequired = function() {
     var typeDescriptor = model.getElementDescriptor(model.getType(this.$type));
@@ -62,7 +62,7 @@ Factory.prototype.createType = function(descriptor) {
         }
       }
     }, this);
-  }
+  };
 
   var name = descriptor.ns.name;
 

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -150,7 +150,7 @@ Properties.prototype.constrainValue = function(property, value) {
   throw new Error(
     'Property <' + property.name + '> has field constraint but no constraints'
   );
-}
+};
 
 
 function isUndefined(val) {

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -1,5 +1,11 @@
 'use strict';
 
+var reduce = require('lodash/collection/reduce'),
+    assign = require('lodash/object/assign'),
+    mathjs = require('mathjs');
+
+var Types = require('./types');
+
 
 /**
  * A utility that gets and sets properties of model elements.
@@ -39,6 +45,11 @@ Properties.prototype.set = function(target, name, value) {
     // set the property, defining well defined properties on the fly
     // or simply updating them in target.$attrs (for extensions)
     if (property) {
+      if (!this.constrainValue(property, value)) {
+        throw new Error(
+          value + ' did not met constraints of property <' + property.name + '>'
+        );
+      }
       if (propertyName in target) {
         target[propertyName] = value;
       } else {
@@ -102,6 +113,44 @@ Properties.prototype.defineDescriptor = function(target, descriptor) {
 Properties.prototype.defineModel = function(target, model) {
   this.define(target, '$model', { value: model });
 };
+
+
+Properties.prototype.constrainValue = function(property, value) {
+  var constraint = property.constraint;
+  if (!constraint || !Types.isBuiltIn(property.type) || property.type === 'Element') {
+    return true;
+  }
+
+  if (property.isMany) {
+    var p = assign({}, property, { isMany: false });
+    return reduce(value, function(result, v) {
+      return result && this.constrainValue(p, v);
+    }, true, this);
+  }
+
+  if (constraint.enum) {
+    for (var i in constraint.enum) {
+      if (constraint.enum[i] === value) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  if (constraint.math) {
+    return mathjs.eval(constraint.math, {
+      x: value,
+    });
+  }
+
+  if (constraint.regex) {
+    return RegExp(constraint.regex).test(value);
+  }
+
+  throw new Error(
+    'Property <' + property.name + '> has field constraint but no constraints'
+  );
+}
 
 
 function isUndefined(val) {

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -144,7 +144,7 @@ Properties.prototype.constrainValue = function(property, value) {
   }
 
   if (constraint.regex) {
-    return RegExp(constraint.regex).test(value);
+    return new RegExp(constraint.regex).test(value);
   }
 
   throw new Error(

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "mocha": "^2.1.0"
   },
   "dependencies": {
+    "mathjs": "^3.16.0",
     "lodash": "^3.0.0"
   }
 }

--- a/test/fixtures/model/constraints.json
+++ b/test/fixtures/model/constraints.json
@@ -1,0 +1,53 @@
+{
+  "name": "Constraints",
+  "uri": "https://constraints",
+  "prefix": "cnstr",
+  "types": [
+    {
+      "name": "Person",
+      "properties": [
+        {
+          "name": "gender",
+          "type": "String",
+          "isAttr": true,
+          "constraint": {
+            "enum": [ "male", "female", "genderFluid" ]
+          }
+        },
+        {
+          "name": "age",
+          "type": "Integer",
+          "isAttr": true,
+          "constraint": {
+            "math": "0 <= x"
+          }
+        },
+        {
+          "name": "name",
+          "type": "String",
+          "isAttr": true,
+          "constraint": {
+            "regex": "^[A-Z][a-z]* [A-Z][a-z]*(-[A-Z][a-z]*)?$"
+          }
+        },
+        {
+          "name": "emails",
+          "type": "String",
+          "isBody": true,
+          "isMany": true,
+          "constraint": {
+            "regex": "^.+@.+\\..+$"
+          }
+        },
+        {
+          "name": "Spouse",
+          "type": "Person",
+          "isBody": true,
+          "constraint": {
+            "enum": [ { "age": "10" } ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/model/constraints.json
+++ b/test/fixtures/model/constraints.json
@@ -68,7 +68,10 @@
           "name": "theNumber",
           "type": "Real",
           "isAttribute": true,
-          "isRequired": true
+          "isRequired": true,
+          "constraint": {
+            "enum": [ 1 ]
+          }
         }
       ]
     }

--- a/test/fixtures/model/constraints.json
+++ b/test/fixtures/model/constraints.json
@@ -48,6 +48,29 @@
           }
         }
       ]
+    },
+    {
+      "name": "NonEmptyList",
+      "properties": [
+        {
+          "name": "entries",
+          "type": "Integer",
+          "isMany": true,
+          "isBody": true,
+          "isRequired": true
+        }
+      ]
+    },
+    {
+      "name": "ANumber",
+      "properties": [
+        {
+          "name": "theNumber",
+          "type": "Real",
+          "isAttribute": true,
+          "isRequired": true
+        }
+      ]
     }
   ]
 }

--- a/test/fixtures/model/properties.json
+++ b/test/fixtures/model/properties.json
@@ -81,7 +81,7 @@
       "name": "BaseWithNumericId",
       "superClass": [ "BaseWithId" ],
       "properties": [
-        { "name": "idNumeric", "type": "String", "isAttr": true, "redefines": "BaseWithId#id", "isId": true }
+        { "name": "idNumeric", "type": "Integer", "isAttr": true, "redefines": "BaseWithId#id", "isId": true }
       ]
     },
     {

--- a/test/spec/constraints.js
+++ b/test/spec/constraints.js
@@ -95,4 +95,12 @@ describe('constraints', function() {
     expect(invalidList.isValid()).to.be.false;
     expect(invalidNumber.isValid()).to.be.false;
   });
+
+  it('should set uniquely required properties accordingly', function() {
+
+    var number = model.create('cnstr:ANumber');
+    number.setUniquelyRequired();
+
+    expect(number.theNumber).to.equal(1);
+  });
 });

--- a/test/spec/constraints.js
+++ b/test/spec/constraints.js
@@ -75,4 +75,24 @@ describe('constraints', function() {
       spouse: spouse
     });
   });
+
+  it('should recognize elements correctly as valid', function() {
+
+    var validList = model.create('cnstr:NonEmptyList', {
+      entries: [ 1 ]
+    });
+
+    var validNumber = model.create('cnstr:ANumber', {
+      theNumber: 1
+    });
+
+    var invalidList = model.create('cnstr:NonEmptyList');
+
+    var invalidNumber = model.create('cnstr:ANumber');
+
+    expect(validList.isValid()).to.be.true;
+    expect(validNumber.isValid()).to.be.true;
+    expect(invalidList.isValid()).to.be.false;
+    expect(invalidNumber.isValid()).to.be.false;
+  });
 });

--- a/test/spec/constraints.js
+++ b/test/spec/constraints.js
@@ -1,0 +1,78 @@
+'use strict';
+
+var Helper = require('../helper');
+
+
+describe('constraints', function() {
+
+  var createModel = Helper.createModelBuilder('test/fixtures/model/');
+  var model = createModel([ 'constraints' ]);
+
+  it('should accept allowed values', function() {
+
+    var g = 'male',
+        a = 30,
+        n = 'Max Mustermann-Musterlich';
+
+    var p = model.create('cnstr:Person', {
+      gender: g,
+      age: a,
+      name: n
+    });
+
+    expect(p.gender).to.equal(g);
+    expect(p.age).to.equal(a);
+    expect(p.name).to.equal(n);
+  });
+
+  it('should reject wrong values', function() {
+
+    try {
+      model.create('cnstr:Person', {
+        gender: 'mascfluid'
+      });
+    } catch (e) {
+      var genderRejected = true;
+    }
+
+    try {
+      model.create('cnstr:Person', {
+        age: -10
+      });
+    } catch (e) {
+      var ageRejected = true;
+    }
+
+    try {
+      model.create('cnstr:Person', {
+        name: 'this-is-an@email.adress'
+      });
+    } catch (e) {
+      var nameRejected = true;
+    }
+
+    expect(genderRejected).to.exist;
+    expect(ageRejected).to.exist;
+    expect(nameRejected).to.exist;
+  });
+
+  it('should constrain constrain collections', function() {
+
+    var e = [ 'a@b.c', 'e@f.d' ];
+
+    var p = model.create('cnstr:Person', {
+      emails: e
+    });
+
+    expect(p.emails).to.equal(e);
+  });
+
+  it('should constrain only built-in types', function() {
+
+    var spouse = model.create('cnstr:Person');
+
+    var p = model.create('cnstr:Person', {
+      spouse: spouse
+    });
+  });
+});


### PR DESCRIPTION
Adds three types of constraints on properties of a built-in type. These constraints are checked whenever `Base#set` respectively `Properties#set` is called,

These are the three types of constraints added:
1. `enum` checks the value against a list of possible values.
2. `regex` checks the value against a regular expression.
3. `math` checks the value against a [mathjs-Expression](http://mathjs.org/docs/expressions/syntax.html).

You can find examples in the [test-case](https://github.com/bpmn-io/moddle/compare/master...felixlinker:properties-constraints?expand=1#diff-24a892db5c7d9c052238218aaa1e9f7f) which builds up on [this json](https://github.com/bpmn-io/moddle/compare/master...felixlinker:properties-constraints?expand=1#diff-9dac79a0518f58c45736a5dbf6e7f86c).