### PR TITLE
fix: make Any#$instanceOf non-enumerable

### DIFF
--- a/lib/moddle.js
+++ b/lib/moddle.js
@@ -153,6 +153,7 @@ Moddle.prototype.createAny = function(name, nsUri, properties) {
   this.properties.defineDescriptor(element, descriptor);
   this.properties.defineModel(element, this);
   this.properties.define(element, '$parent', { enumerable: false, writable: true });
+  this.properties.define(element, '$instanceOf', { enumerable: false, writable: true });
 
   forEach(properties, function(a, key) {
     if (isObject(a) && a.value !== undefined) {

--- a/test/spec/moddle.js
+++ b/test/spec/moddle.js
@@ -181,6 +181,31 @@ describe('moddle', function() {
         });
       });
 
+
+      it('should return non-enumerable special props', function() {
+
+        // given
+        var anyInstance = model.createAny('other:Foo', 'http://other', {
+          bar: 'BAR'
+        });
+
+        // assume
+        expect(anyInstance).not.to.have.keys([
+          '$parent',
+          '$instanceOf'
+        ]);
+
+        // when
+        anyInstance.$parent = 'foo';
+        anyInstance.$instanceOf = 'bar';
+
+        // then
+        expect(anyInstance).not.to.have.keys([
+          '$parent',
+          '$instanceOf'
+        ]);
+      });
+
     });
 
 


### PR DESCRIPTION
This ensures $instanceOf is not exposed when traversing an Any-moddle
elements properties.

The property _is_ non-enumerable for defined moddle elements already. This is why I consider this a bug.

---

One use case for this is enumerating all properties (note that I do not have to enumerate the `$instanceOf` member):

```javascript

// given
var xml = `
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<bpmn:definitions
  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
  xmlns:i18n="http://www.omg.org/spec/BPMN/non-normative/extensions/i18n/1.0"
  id="Definitions_1"
  targetNamespace="http://bpmn.io/schema/bpmn">
  <bpmn:collaboration id="Collaboration_1">
    <bpmn:extensionElements>
      <i18n:translation target="@name" xml:lang="en">Advertise</i18n:translation>
    </bpmn:extensionElements>
  </bpmn:collaboration>
</bpmn:definitions>`;

// when
var {
  rootElement
} = await read(xml);

expect(rootElement).to.jsonEqual({
  "$type": "bpmn:Definitions",
  "id": "Definitions_1",
  "rootElements": [
    {
      "$type": "bpmn:Collaboration",
      "id": "Collaboration_1",
      "extensionElements": {
        "$type": "bpmn:ExtensionElements",
        "values": [
          {
            "$body": "Advertise",
            "$type": "i18n:translation",
            "target": "@name"
          }
        ]
      }
    }
  ]
});
```