### PR TITLE
Remove element from builtins

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -5,8 +5,7 @@ var BUILTINS = {
   String: true,
   Boolean: true,
   Integer: true,
-  Real: true,
-  Element: true
+  Real: true
 };
 
 /**

--- a/test/fixtures/model/element.json
+++ b/test/fixtures/model/element.json
@@ -1,0 +1,21 @@
+{
+  "name": "Element",
+  "uri": "http://element",
+  "prefix": "e",
+  "types": [
+    {
+      "name": "Element",
+      "isAbstract": true,
+      "properties": [
+        { "name": "children", "type": "Element", "isMany": true }
+      ]
+    },
+    {
+      "name": "NamedElement",
+      "superClass": [ "Element" ],
+      "properties": [
+        { "name": "name", "type": "String" }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/model/extension/custom.json
+++ b/test/fixtures/model/extension/custom.json
@@ -4,6 +4,10 @@
   "prefix": "c",
   "types": [
     {
+      "name": "Element",
+      "isAbstract": true
+    },
+    {
       "name": "CustomRoot",
       "superClass": [ "Base" ],
       "extends": [ "b:Root" ],

--- a/test/spec/element.js
+++ b/test/spec/element.js
@@ -1,0 +1,46 @@
+import expect from '../expect';
+import { createModelBuilder } from '../helper';
+
+describe('element', function() {
+
+  var createModel = createModelBuilder('test/fixtures/model/');
+  var model = createModel([ 'element' ]);
+
+  it('should provide type descriptor for Element', function() {
+
+    // given
+    var elementType = model.getType('e:Element');
+    var expectedDescriptor = model.getElementDescriptor(elementType);
+
+    // when
+    var descriptor = elementType.$descriptor;
+
+    // then
+    expect(descriptor).to.equal(expectedDescriptor);
+  });
+
+  it('should provide type descriptor for NamedElement', function() {
+
+    // given
+    var namedElementType = model.getType('e:NamedElement');
+    var expectedDescriptor = model.getElementDescriptor(namedElementType);
+
+    // when
+    var descriptor = namedElementType.$descriptor;
+
+    // then
+    expect(descriptor).to.equal(expectedDescriptor);
+  });
+
+  it('should create NamedElement instance', function() {
+
+    // when
+    var instance = model.create('e:NamedElement');
+
+    // then
+    expect(instance).to.exist;
+    expect(instance.$instanceOf('e:NamedElement')).to.be.true;
+    expect(instance.$instanceOf('e:Element')).to.be.true;
+  });
+
+});

--- a/test/spec/extension.js
+++ b/test/spec/extension.js
@@ -109,7 +109,7 @@ describe('moddle', function() {
         var customGeneric = model.create('c:CustomGeneric', { count: 100 });
 
         // then
-        expect(customGeneric.$instanceOf('Element')).to.be.true;
+        expect(customGeneric.$instanceOf('c:Element')).to.be.true;
       });
 
 

--- a/test/spec/types.js
+++ b/test/spec/types.js
@@ -33,14 +33,6 @@ describe('Types', function() {
       expect(coerceType('Integer', '12012')).to.equal(12012);
     });
 
-
-    it('should NOT convert complex', function() {
-      var complexElement = { a: 'A' };
-      expect(coerceType('Element', complexElement)).to.equal(complexElement);
-    });
-
   });
 
 });
-
-


### PR DESCRIPTION
- Removes 'Element' from the built-in types and adopts existing unit tests.
- A Test is added to verify that Element can be part of a model hierarchy.

Closes #30.
