### PR TITLE
Add prepare script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "mocha -r esm --reporter=spec --recursive test/spec",
     "distro": "run-s build test:build",
     "build": "rollup -c",
+    "prepare": "npm run build",
     "test:build": "mocha --reporter=spec --recursive test/distro",
     "prepublishOnly": "run-s distro"
   },


### PR DESCRIPTION
Allows this package to be installed from a git repository instead of a the npm registry. The script will be run upon local `npm install` ([see](https://docs.npmjs.com/cli/v6/using-npm/scripts#life-cycle-scripts)).

Without a prepare script, the *dist* folder inside *node_modules/moddle* is missing after installation and effectively the package cannot be used.

Closes #34.