### PR TITLE
test: extend builtin shadowing test

### DIFF
--- a/test/fixtures/model/extension/uml.json
+++ b/test/fixtures/model/extension/uml.json
@@ -6,6 +6,10 @@
     {
       "name": "Element",
       "properties": []
+    },
+    {
+      "name": "NamedElement",
+      "superClass": [ "uml:Element" ]
     }
   ]
 }

--- a/test/spec/extension.js
+++ b/test/spec/extension.js
@@ -10,9 +10,9 @@ describe('moddle', function() {
   var createModel = createModelBuilder('test/fixtures/model/');
 
 
-  describe('name shadowing', function() {
+  describe('built in name shadowing', function() {
 
-    it('should allow to shadow Element', function() {
+    it('should shadow <Element>', function() {
 
       // given
       var model = createModel([ 'extension/uml' ]);
@@ -23,6 +23,21 @@ describe('moddle', function() {
       // then
       expect(element).to.exist;
       expect(element.$instanceOf('uml:Element')).to.be.true;
+    });
+
+
+    it('should shadow <Element> in inheritance hierarchy', function() {
+
+      // given
+      var model = createModel([ 'extension/uml' ]);
+
+      // when
+      var element = model.create('uml:NamedElement');
+
+      // then
+      expect(element).to.exist;
+      expect(element.$instanceOf('uml:Element')).to.be.true;
+      expect(element.$instanceOf('uml:NamedElement')).to.be.true;
     });
 
   });


### PR DESCRIPTION
Ensure that built-in names can be shadowed with package namespace.

This verifies that we correctly handle namespaced _builtin_ names as package defined types.

----

Related to https://github.com/bpmn-io/moddle/issues/30#issuecomment-828352094