### PR TITLE
Multiple inherited properties

### DIFF
--- a/lib/descriptor-builder.js
+++ b/lib/descriptor-builder.js
@@ -135,11 +135,13 @@ DescriptorBuilder.prototype.addNamedProperty = function(p, validate) {
       propsByName = this.propertiesByName;
 
   if (validate) {
-    this.assertNotDefined(p, ns.name);
-    this.assertNotDefined(p, ns.localName);
+    this.assertNotDefined(p);
   }
 
-  propsByName[ns.name] = propsByName[ns.localName] = p;
+  if (!this.propertiesByName[ns.name])
+    propsByName[ns.name] = propsByName[ns.localName] = p;
+  else if (!this.propertiesByName[ns.localName])
+    propsByName[ns.localName] = p;
 };
 
 DescriptorBuilder.prototype.removeNamedProperty = function(p) {
@@ -172,15 +174,18 @@ DescriptorBuilder.prototype.setIdProperty = function(p, validate) {
   this.idProperty = p;
 };
 
-DescriptorBuilder.prototype.assertNotDefined = function(p, name) {
-  var propertyName = p.name,
+DescriptorBuilder.prototype.assertNotDefined = function(p) {
+  var ns = p.ns,
+      propertyName = p.name,
       definedProperty = this.propertiesByName[propertyName];
 
-  if (definedProperty) {
+  if (this.propertiesByName[ns.name] && this.propertiesByName[ns.localName]) {
     throw new Error(
       'property <' + propertyName + '> already defined; ' +
-      'override of <' + definedProperty.definedBy.ns.name + '#' + definedProperty.ns.name + '> by ' +
-      '<' + p.definedBy.ns.name + '#' + p.ns.name + '> not allowed without redefines');
+        'override of <' + definedProperty.definedBy.ns.name + '#' +
+        definedProperty.ns.name + '> by ' +
+        '<' + p.definedBy.ns.name + '#' + p.ns.name +
+        '> not allowed without redefines');
   }
 };
 

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -19,8 +19,7 @@ export default function Properties(model) {
 Properties.prototype.set = function(target, name, value) {
 
   var property = this.model.getPropertyDescriptor(target, name);
-
-  var propertyName = property && property.name;
+  var propertyName = getPropertyName(target, name, property);
 
   if (isUndefined(value)) {
     // unset the property, if the specified value is undefined;
@@ -37,13 +36,19 @@ Properties.prototype.set = function(target, name, value) {
       if (propertyName in target) {
         target[propertyName] = value;
       } else {
-        defineProperty(target, property, value);
+        Object.defineProperty(target, propertyName, {
+          enumerable: !property.isReference,
+          writable: true,
+          value: value,
+          configurable: true
+        });
       }
     } else {
       target.$attrs[name] = value;
     }
   }
 };
+
 
 /**
  * Returns the named property of the given element
@@ -61,11 +66,16 @@ Properties.prototype.get = function(target, name) {
     return target.$attrs[name];
   }
 
-  var propertyName = property.name;
+  var propertyName = getPropertyName(target, name, property);
 
   // check if access to collection property and lazily initialize it
   if (!target[propertyName] && property.isMany) {
-    defineProperty(target, property, []);
+    Object.defineProperty(target, propertyName, {
+      enumerable: !property.isReference,
+      writable: true,
+      value: [],
+      configurable: true
+    });
   }
 
   return target[propertyName];
@@ -103,11 +113,19 @@ function isUndefined(val) {
   return typeof val === 'undefined';
 }
 
-function defineProperty(target, property, value) {
-  Object.defineProperty(target, property.name, {
-    enumerable: !property.isReference,
-    writable: true,
-    value: value,
-    configurable: true
-  });
+
+function getPropertyName(target, name, descriptor) {
+  if (!target || !name || !descriptor)
+    return undefined;
+
+  var propertyName = descriptor.name;
+
+  if (name.includes(':')) {
+    var parts = name.split(':');
+
+    if (parts[0] !== target.$descriptor.ns.prefix)
+      propertyName = descriptor.ns.name;
+  }
+
+  return propertyName;
 }

--- a/test/fixtures/model/multiple-inherited-properties.json
+++ b/test/fixtures/model/multiple-inherited-properties.json
@@ -1,0 +1,23 @@
+{
+  "name": "MultipleInheritance",
+  "uri": "http://multipleinheritance",
+  "prefix": "mh",
+  "types": [
+    {
+      "name": "AnotherRoot",
+      "properties": [
+        {
+          "name": "any",
+          "type": "AnotherRoot",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "MultipleInherited",
+      "superClass": [ "AnotherRoot", "props:Root" ],
+      "properties": [
+      ]
+    }
+  ]
+}

--- a/test/fixtures/model/properties.json
+++ b/test/fixtures/model/properties.json
@@ -85,6 +85,13 @@
       ]
     },
     {
+      "name": "BaseWithAlreadyDefinedId",
+      "superClass": [ "BaseWithId" ],
+      "properties": [
+        { "name": "id", "type": "Integer", "isAttr": true, "isId": true }
+      ]
+    },
+    {
       "name": "Attributes",
       "superClass": [ "BaseWithId" ],
       "properties": [

--- a/test/spec/properties.js
+++ b/test/spec/properties.js
@@ -73,6 +73,16 @@ describe('properties', function() {
       expect(inheritedAnyProperty).to.exist;
     });
 
+    it('should NOT add already defined property without redefine', function() {
+
+      // when
+      var getType = function () {
+        model.getType('props:BaseWithAlreadyDefinedId');
+      };
+
+      // then
+      expect(getType).to.throw(Error);
+    });
   });
 
 

--- a/test/spec/properties.js
+++ b/test/spec/properties.js
@@ -77,7 +77,7 @@ describe('properties', function() {
     it('should NOT add already defined property without redefine', function() {
 
       // when
-      var getType = function () {
+      var getType = function() {
         model.getType('props:BaseWithAlreadyDefinedId');
       };
 
@@ -504,7 +504,6 @@ describe('properties', function() {
         expect(instance).to.exist;
       });
 
-
       describe('get', function() {
 
         it('access via original name', function() {
@@ -513,7 +512,7 @@ describe('properties', function() {
           var instance = mhModel.create('mh:MultipleInherited');
 
           // when
-          var property = instance.get("any");
+          var property = instance.get('any');
 
           // then
           expect(property).to.exist;
@@ -526,7 +525,7 @@ describe('properties', function() {
           var instance = mhModel.create('mh:MultipleInherited');
 
           // when
-          var property = instance.get("mh:any");
+          var property = instance.get('mh:any');
 
           // then
           expect(property).to.exist;
@@ -539,7 +538,7 @@ describe('properties', function() {
           var instance = mhModel.create('mh:MultipleInherited');
 
           // when
-          var property = instance.get("props:any");
+          var property = instance.get('props:any');
 
           // then
           expect(property).to.exist;
@@ -556,10 +555,10 @@ describe('properties', function() {
           var instance = mhModel.create('mh:MultipleInherited');
 
           // when
-          instance.set("any", [ "test" ]);
-          var originalProperty = instance.get("any");
-          var localProperty = instance.get("mh:any");
-          var otherProperty = instance.get("props:any");
+          instance.set('any', [ 'test' ]);
+          var originalProperty = instance.get('any');
+          var localProperty = instance.get('mh:any');
+          var otherProperty = instance.get('props:any');
 
           // then
           expect(originalProperty.length).to.equal(1);
@@ -571,10 +570,10 @@ describe('properties', function() {
 
           // when
           var instance = mhModel.create('mh:MultipleInherited');
-          instance.set("mh:any", [ "test" ]);
-          var originalProperty = instance.get("any");
-          var localProperty = instance.get("mh:any");
-          var otherProperty = instance.get("props:any");
+          instance.set('mh:any', [ 'test' ]);
+          var originalProperty = instance.get('any');
+          var localProperty = instance.get('mh:any');
+          var otherProperty = instance.get('props:any');
 
           // then
           expect(originalProperty.length).to.equal(1);
@@ -587,10 +586,10 @@ describe('properties', function() {
 
           // when
           var instance = mhModel.create('mh:MultipleInherited');
-          instance.set("props:any", [ "test" ]);
-          var originalProperty = instance.get("any");
-          var localProperty = instance.get("mh:any");
-          var otherProperty = instance.get("props:any");
+          instance.set('props:any', [ 'test' ]);
+          var originalProperty = instance.get('any');
+          var localProperty = instance.get('mh:any');
+          var otherProperty = instance.get('props:any');
 
           // then
           expect(originalProperty.length).to.equal(0);

--- a/test/spec/properties.js
+++ b/test/spec/properties.js
@@ -73,6 +73,7 @@ describe('properties', function() {
       expect(inheritedAnyProperty).to.exist;
     });
 
+
     it('should NOT add already defined property without redefine', function() {
 
       // when
@@ -83,6 +84,7 @@ describe('properties', function() {
       // then
       expect(getType).to.throw(Error);
     });
+
   });
 
 
@@ -464,5 +466,142 @@ describe('properties', function() {
     });
 
   });
+
+  describe('multiple inherited properties', function() {
+
+    // const createModel = createModelBuilder('test/fixtures/model/');
+    var mhModel = createModel([
+      'properties',
+      'multiple-inherited-properties'
+    ]);
+
+    describe('descriptor', function() {
+
+      it('should provide type', function() {
+
+        // when
+        var Type = mhModel.getType('mh:MultipleInherited');
+        var descriptor = model.getElementDescriptor(Type);
+
+        // then
+        expect(Type).to.exist;
+        expect(descriptor).to.exist;
+        expect(descriptor.propertiesByName.any).to.exist;
+        expect(descriptor.propertiesByName['mh:any']).to.exist;
+        expect(descriptor.propertiesByName['props:any']).to.exist;
+      });
+
+    });
+
+    describe('instance', function() {
+
+      it('should create instance', function() {
+
+        // when
+        var instance = mhModel.create('mh:MultipleInherited');
+
+        // then
+        expect(instance).to.exist;
+      });
+
+
+      describe('get', function() {
+
+        it('access via original name', function() {
+
+          // given
+          var instance = mhModel.create('mh:MultipleInherited');
+
+          // when
+          var property = instance.get("any");
+
+          // then
+          expect(property).to.exist;
+        });
+
+
+        it('access via local name', function() {
+
+          // given
+          var instance = mhModel.create('mh:MultipleInherited');
+
+          // when
+          var property = instance.get("mh:any");
+
+          // then
+          expect(property).to.exist;
+        });
+
+
+        it('access via other name', function() {
+
+          // given
+          var instance = mhModel.create('mh:MultipleInherited');
+
+          // when
+          var property = instance.get("props:any");
+
+          // then
+          expect(property).to.exist;
+        });
+
+      }); // describe(multiple inherited properties/instance/get)
+
+
+      describe('set', function() {
+
+        it('via original name', function() {
+
+          // given
+          var instance = mhModel.create('mh:MultipleInherited');
+
+          // when
+          instance.set("any", [ "test" ]);
+          var originalProperty = instance.get("any");
+          var localProperty = instance.get("mh:any");
+          var otherProperty = instance.get("props:any");
+
+          // then
+          expect(originalProperty.length).to.equal(1);
+          expect(localProperty.length).to.equal(1);
+          expect(otherProperty.length).to.equal(0);
+        });
+
+        it('via local name', function() {
+
+          // when
+          var instance = mhModel.create('mh:MultipleInherited');
+          instance.set("mh:any", [ "test" ]);
+          var originalProperty = instance.get("any");
+          var localProperty = instance.get("mh:any");
+          var otherProperty = instance.get("props:any");
+
+          // then
+          expect(originalProperty.length).to.equal(1);
+          expect(localProperty.length).to.equal(1);
+          expect(otherProperty.length).to.equal(0);
+        });
+
+
+        it('via other name', function() {
+
+          // when
+          var instance = mhModel.create('mh:MultipleInherited');
+          instance.set("props:any", [ "test" ]);
+          var originalProperty = instance.get("any");
+          var localProperty = instance.get("mh:any");
+          var otherProperty = instance.get("props:any");
+
+          // then
+          expect(originalProperty.length).to.equal(0);
+          expect(localProperty.length).to.equal(0);
+          expect(otherProperty.length).to.equal(1);
+        });
+
+      }); // describe(multiple inherited properties/instance/set)
+
+    }); // describe(multiple inherited properties/instance)
+
+  }); // describe(multiple inherited properties)
 
 });


### PR DESCRIPTION
This fixes the problem as long as the properties have different namespaces.

Naming conflicts resulting from multiple inheritance within the same model are not resolved. E.g.:
![multiple-inheritance-same-model](https://user-images.githubusercontent.com/8592509/116673566-d7c97680-a9a3-11eb-85e0-8654e6b3c8b8.png)

If the scope for namespaces were expanded to types, the properties could be seperated and mapped accordingly. But I doubt that this is necessary (or even useful) as long as *moddle* has no explicit namespacing (e.g. with a new keyword; which could be a useful extension). IMO, a proper model design should avoid this kind of conflicts and it seems to be quite some effort to implement.

Closes #36.