### PR TITLE
Improve error thrown on trait introspection

### DIFF
--- a/lib/descriptor-builder.js
+++ b/lib/descriptor-builder.js
@@ -172,6 +172,17 @@ DescriptorBuilder.prototype.setIdProperty = function(p, validate) {
   this.idProperty = p;
 };
 
+DescriptorBuilder.prototype.assertNotTrait = function(typeDescriptor) {
+
+  const _extends = typeDescriptor.extends || [];
+
+  if (_extends.length) {
+    throw new Error(
+      `cannot create <${ typeDescriptor.name }> extending <${ typeDescriptor.extends }>`
+    );
+  }
+};
+
 DescriptorBuilder.prototype.assertNotDefined = function(p, name) {
   var propertyName = p.name,
       definedProperty = this.propertiesByName[propertyName];
@@ -189,6 +200,10 @@ DescriptorBuilder.prototype.hasProperty = function(name) {
 };
 
 DescriptorBuilder.prototype.addTrait = function(t, inherited) {
+
+  if (inherited) {
+    this.assertNotTrait(t);
+  }
 
   var typesByName = this.allTypesByName,
       types = this.allTypes;

--- a/test/spec/extension.js
+++ b/test/spec/extension.js
@@ -50,6 +50,14 @@ describe('moddle', function() {
 
     describe('trait', function() {
 
+      it('should not provide meta-data', function() {
+
+        expect(() => {
+          model.getType('c:CustomRoot');
+        }).to.throw(/cannot create <c:CustomRoot> extending <b:Root>/);
+      });
+
+
       describe('descriptor', function() {
 
         it('should indicate non-inherited', function() {


### PR DESCRIPTION
Traits are not meant to be instantiated; their types can usually not be retrieved.

This PR ensures such miss-use is properly indicated to the user.

Closes #38