### PR TITLE
Fix inherits with multiple super classes

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -136,23 +136,32 @@ Registry.prototype.mapTypes = function(nsName, iterator, trait) {
   var self = this;
 
   /**
-   * Traverse the selected trait.
-   *
-   * @param {String} cls
-   */
-  function traverseTrait(cls) {
-    return traverseSuper(cls, true);
-  }
-
-  /**
    * Traverse the selected super type or trait
    *
    * @param {String} cls
    * @param {Boolean} [trait=false]
    */
-  function traverseSuper(cls, trait) {
+  function traverse(cls, trait) {
     var parentNs = parseNameNs(cls, isBuiltInType(cls) ? '' : nsName.prefix);
     self.mapTypes(parentNs, iterator, trait);
+  }
+
+  /**
+   * Traverse the selected trait.
+   *
+   * @param {String} cls
+   */
+  function traverseTrait(cls) {
+    return traverse(cls, true);
+  }
+
+  /**
+   * Traverse the selected super type
+   *
+   * @param {String} cls
+   */
+  function traverseSuper(cls) {
+    return traverse(cls, false);
   }
 
   if (!type) {

--- a/test/fixtures/model/properties.json
+++ b/test/fixtures/model/properties.json
@@ -169,6 +169,14 @@
           "isMany": true
         }
       ]
+    },
+    {
+      "name": "MultipleSuper",
+      "superClass": [
+        "Base",
+        "BaseWithId",
+        "SimpleBody"
+      ]
     }
   ]
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -6,6 +6,8 @@ import {
 
 import { Moddle } from '../lib/index.js';
 
+import expect from './expect.js';
+
 
 export function readFile(filename) {
   return fs.readFileSync(filename, { encoding: 'UTF-8' });
@@ -40,4 +42,29 @@ export function createModelBuilder(base) {
   }
 
   return createModel;
+}
+
+/**
+ * @param {Object} descriptor
+ * @param {string[]} expectedPropertyNames
+ */
+export function expectOrderedProperties(descriptor, expectedPropertyNames) {
+  var propertyNames = descriptor.properties.map(function(p) {
+    return p.name;
+  });
+
+  // then
+  expect(propertyNames).to.eql(expectedPropertyNames);
+}
+
+/**
+ * @param {Moddle} model
+ * @param {string} typeName
+ *
+ * @return {Object} descriptor
+ */
+export function getEffectiveDescriptor(model, typeName) {
+  var Type = model.getType(typeName);
+
+  return model.getElementDescriptor(Type);
 }

--- a/test/spec/extension.js
+++ b/test/spec/extension.js
@@ -5,7 +5,7 @@ import {
 } from '../helper.js';
 
 
-describe('moddle', function() {
+describe('extension', function() {
 
   var createModel = createModelBuilder('test/fixtures/model/');
 

--- a/test/spec/meta.js
+++ b/test/spec/meta.js
@@ -10,6 +10,7 @@ describe('meta', function() {
   var createModel = createModelBuilder('test/fixtures/model/');
   var model = createModel([ 'meta' ]);
 
+
   it('should have the "meta" attribute', function() {
 
     // when


### PR DESCRIPTION
Due to a simple [programming bug](https://github.com/bpmn-io/moddle/compare/fix-inherits?expand=1#diff-c76cf141522a047fee59ae738cbc8a0dc2c48ed15666d958d407d867c3a4b69fL153) `forEach` would pass index values bigger than `0` into `traverseSuper`, making all but the first inherited base a _trait_ rather than an inherited super type.

Beyond being a silly bug this has the impact of properties not being tagged appropriately, too.