### PR TITLE
test: verify built-in `Element` access

### DIFF
--- a/test/fixtures/model/shadow.json
+++ b/test/fixtures/model/shadow.json
@@ -10,6 +10,12 @@
     {
       "name": "NamedElement",
       "superClass": [ "s:Element" ]
+    },
+    {
+      "name": "ExtendsBuiltinElement",
+      "superClass": [
+        "Element"
+      ]
     }
   ]
 }

--- a/test/spec/extension.js
+++ b/test/spec/extension.js
@@ -40,6 +40,18 @@ describe('extension', function() {
         expect(element.$instanceOf('s:NamedElement')).to.be.true;
       });
 
+
+      it('should provide <Element> built-in type', function() {
+
+        // when
+        var element = model.create('s:ExtendsBuiltinElement');
+
+        // then
+        expect(element).to.exist;
+        expect(element.$instanceOf('Element')).to.be.true;
+        expect(element.$instanceOf('s:ExtendsBuiltinElement')).to.be.true;
+      });
+
     });
 
   });
@@ -231,5 +243,11 @@ describe('extension', function() {
     });
 
   });
+
+});
+
+
+describe('extension - self extend', function() {
+
 
 });


### PR DESCRIPTION
Ensures we can use the built-in `Element` in inheritance hierarchies.