### PR TITLE
fix: allow self-extension without namespace prefix

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -106,7 +106,9 @@ Registry.prototype.registerType = function(type, pkg) {
   });
 
   forEach(type.extends, bind(function(extendsName) {
-    var extended = this.typeMap[extendsName];
+    var extendsNameNs = parseNameNs(extendsName, ns.prefix);
+
+    var extended = this.typeMap[extendsNameNs.name];
 
     extended.traits = extended.traits || [];
     extended.traits.push(name);

--- a/test/fixtures/model/self-extend.json
+++ b/test/fixtures/model/self-extend.json
@@ -1,0 +1,18 @@
+{
+  "name": "Self Extend",
+  "uri": "http://self-extend",
+  "prefix": "se",
+  "types": [
+    {
+      "name": "Rect"
+    },
+    {
+      "name": "ExtendedRect",
+      "extends": [ "Rect" ]
+    },
+    {
+      "name": "OtherExtendedRect",
+      "extends": [ "se:Rect" ]
+    }
+  ]
+}

--- a/test/spec/extension.js
+++ b/test/spec/extension.js
@@ -232,4 +232,17 @@ describe('extension', function() {
 
   });
 
+
+  it('should self-extend', async function() {
+
+    // when
+    var model = createModel([ 'self-extend' ]);
+
+    var element = model.create('se:Rect');
+
+    // then
+    expect(element.$instanceOf('se:ExtendedRect')).to.be.true;
+    expect(element.$instanceOf('se:OtherExtendedRect')).to.be.true;
+  });
+
 });


### PR DESCRIPTION
Ensure we can use self-extension without explicitly namespace prefix.