### PR TITLE
fix(moddle): define accessors as non-enumerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [moddle](https://github.com/bpmn-io/moddle) are documente
 
 ___Note:__ Yet to be released changes appear here._
 
+## 6.2.3
+
+* `FIX`: mark accessors as non-enumerable ([#55](https://github.com/bpmn-io/moddle/pull/55))
+
 ## 6.2.2
 
 * `FIX`: add accessors for elements created by `createAny` ([#54](https://github.com/bpmn-io/moddle/pull/54))

--- a/lib/moddle.js
+++ b/lib/moddle.js
@@ -163,6 +163,8 @@ Moddle.prototype.createAny = function(name, nsUri, properties) {
 
   this.properties.defineDescriptor(element, descriptor);
   this.properties.defineModel(element, this);
+  this.properties.define(element, 'get', { enumerable: false, writable: true });
+  this.properties.define(element, 'set', { enumerable: false, writable: true });
   this.properties.define(element, '$parent', { enumerable: false, writable: true });
   this.properties.define(element, '$instanceOf', { enumerable: false, writable: true });
 

--- a/test/spec/moddle.js
+++ b/test/spec/moddle.js
@@ -257,6 +257,21 @@ describe('moddle', function() {
         }).to.throw('illegal key type: object. Key should be of type number or string.');
       });
 
+
+      it('should mark accessors as special props', function() {
+
+        // given
+        var anyInstance = model.createAny('other:Foo', 'http://other', {
+          bar: 'BAR'
+        });
+
+        // then
+        expect(anyInstance).not.to.have.keys([
+          'get',
+          'set'
+        ]);
+      });
+
     });
 
 


### PR DESCRIPTION
related to https://github.com/camunda/camunda-modeler/pull/3591#issuecomment-1534281637
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
