### PR TITLE
Make library ESM only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to [moddle](https://github.com/bpmn-io/moddle) are documente
 ___Note:__ Yet to be released changes appear here._
 
 * `DEPS`: update to `min-dash@5`
+* `CHORE`: drop CJS distribution
+
+### Breaking Changes
+
+* Library is now ESM only, and can be consumed in Node >= 20.12
 
 ## 7.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [moddle](https://github.com/bpmn-io/moddle) are documente
 
 ___Note:__ Yet to be released changes appear here._
 
+* `DEPS`: update to `min-dash@5`
+
 ## 7.2.0
 
 * `FEAT`: expose moddle schema via well-known folder ([#64](https://github.com/bpmn-io/moddle/pull/64))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ All notable changes to [moddle](https://github.com/bpmn-io/moddle) are documente
 
 ___Note:__ Yet to be released changes appear here._
 
-* `DEPS`: update to `min-dash@5`
-* `CHORE`: drop CJS distribution
+## 8.0.0
+
+* `DEPS`: update to `min-dash@5` ([#69](https://github.com/bpmn-io/moddle/pull/69))
+* `CHORE`: drop CJS distribution ([#69](https://github.com/bpmn-io/moddle/pull/69))
 
 ### Breaking Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
-        "min-dash": "^4.2.1"
+        "min-dash": "^5.0.0"
       },
       "devDependencies": {
         "ajv": "^8.17.1",
@@ -3094,9 +3094,10 @@
       }
     },
     "node_modules/min-dash": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.1.tgz",
-      "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
+      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -6572,9 +6573,9 @@
       }
     },
     "min-dash": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.1.tgz",
-      "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
+      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw=="
     },
     "minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "npm test -- --watch",
     "test": "mocha --reporter=spec --recursive test",
     "test:schema": "ajv -s resources/schema/moddle.json -d 'test/fixtures/**/*.json'",
-    "build": "rollup -c",
+    "build": "rollup -c --bundleConfigAsCjs",
     "prepare": "run-s build"
   },
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "rollup": "^4.54.0"
   },
   "dependencies": {
-    "min-dash": "^4.2.1"
+    "min-dash": "^5.0.0"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
   },
   "type": "module",
   "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    },
+    ".": "./dist/index.js",
     "./package.json": "./package.json"
   },
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,13 +1,4 @@
-import fs from 'node:fs';
-
-
-const pkg = JSON.parse(fs.readFileSync('./package.json'));
-
-const pkgExports = pkg.exports['.'];
-
-function pgl(plugins = []) {
-  return plugins;
-}
+import pkg from './package.json';
 
 const srcEntry = 'lib/index.js';
 
@@ -20,7 +11,6 @@ export default [
     ],
     external: [
       'min-dash'
-    ],
-    plugins: pgl()
+    ]
   }
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,8 +6,7 @@ export default [
   {
     input: srcEntry,
     output: [
-      { file: pkgExports.require, format: 'cjs', sourcemap: true },
-      { file: pkgExports.import, format: 'es', sourcemap: true }
+      { file: pkg.exports['.'], format: 'es', sourcemap: true }
     ],
     external: [
       'min-dash'

--- a/test/integration/distro.cjs
+++ b/test/integration/distro.cjs
@@ -2,9 +2,6 @@ const {
   expect
 } = require('chai');
 
-const pkg = require('../../package.json');
-const pkgExports = pkg.exports['.'];
-
 
 describe('integration', function() {
 
@@ -18,7 +15,27 @@ describe('integration', function() {
         isBuiltInType,
         parseNameNS,
         coerceType
-      } = require('../../' + pkgExports.require);
+      } = require('moddle');
+
+      expect(new Moddle()).to.exist;
+
+      expect(isSimpleType).to.exist;
+      expect(isBuiltInType).to.exist;
+      expect(parseNameNS).to.exist;
+      expect(coerceType).to.exist;
+    });
+
+
+
+    it('should expose ESM bundle', async function() {
+
+      const {
+        Moddle,
+        isSimpleType,
+        isBuiltInType,
+        parseNameNS,
+        coerceType
+      } = await import('moddle');
 
       expect(new Moddle()).to.exist;
 


### PR DESCRIPTION
### Proposed Changes

Updated library to be ESM only, update to `min-dash@5`.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
