### PR TITLE
fix: expose `ModdleElement` types from package entry

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,9 @@
 export * from '../lib/index.js'
 
 export * from '../lib/moddle.js';
+
+export type {
+  ModdleElement,
+  ModdleElementType,
+  AnyModdleElement
+} from '../lib/factory.js';

--- a/test/integration/distro.ts
+++ b/test/integration/distro.ts
@@ -1,6 +1,9 @@
 import {
   Moddle,
-  PackageDefinition
+  PackageDefinition,
+  ModdleElement,
+  ModdleElementType,
+  AnyModdleElement
 } from 'moddle';
 
 import { expectType } from 'ts-expect';
@@ -108,6 +111,43 @@ describe('integration', function() {
       expectType<unknown>(attrs.get('$attrs'));
 
       attrs.get('attribute').push(attr);
+
+    });
+
+
+    it('should expose element types', function() {
+
+      // given
+      const moddle = new Moddle(packages, { strict: true });
+
+      // ModdleElement<T>
+      const attr = moddle.create<ExamplAttribute>('exampl:Attribute', { key: 'foo', value: 'bar' });
+
+      expectType<ModdleElement<ExamplAttribute>>(attr);
+      expectType<string>(attr.$type);
+      expectType<Record<string, any>>(attr.$attrs);
+      expectType<ModdleElement | AnyModdleElement | undefined>(attr.$parent);
+      expectType<string>(attr.key);
+
+      // ModdleElementType<T>
+      const AttributeType = moddle.getType<ExamplAttribute>('exampl:Attribute');
+
+      expectType<ModdleElementType<ExamplAttribute>>(AttributeType);
+
+      const instance = new AttributeType({ key: 'foo', value: 'bar' });
+
+      expectType<ModdleElement<ExamplAttribute>>(instance);
+      expectType<string>(instance.key);
+
+      // AnyModdleElement<T>
+      const any = moddle.createAny<ExamplAttribute>('vendor:Attribute', 'http://vendor', {
+        key: 'foo',
+        value: 'bar'
+      });
+
+      expectType<AnyModdleElement<ExamplAttribute>>(any);
+      expectType<string>(any.$type);
+      expectType<string>(any.key);
 
     });
 


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/bpmn-io/internal-docs/issues/1345

Re-exports the public element types (`ModdleElement`, `ModdleElementType`, `AnyModdleElement`) from moddle's entry point.

Enables downstream packages (bpmn-moddle, zeebe-bpmn-moddle, …) to type their elements as `ModdleElement<T>`.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
