### PR TITLE
fix: do not resolve Object prototype members in lookups

### DIFF
--- a/lib/descriptor-builder.js
+++ b/lib/descriptor-builder.js
@@ -83,7 +83,7 @@ export default function DescriptorBuilder(nameNs) {
    * @private
    * @type {Record<string, RegisteredTypeDef>}
    */
-  this.allTypesByName = {};
+  this.allTypesByName = Object.create(null);
 
   /**
    * @private
@@ -95,7 +95,7 @@ export default function DescriptorBuilder(nameNs) {
    * @private
    * @type {Record<string, PropertyDescriptor>}
    */
-  this.propertiesByName = {};
+  this.propertiesByName = Object.create(null);
 }
 
 /**

--- a/lib/moddle.js
+++ b/lib/moddle.js
@@ -128,7 +128,7 @@ export default function Moddle(packages, config = {}) {
   /**
    * @type {Record<string,ModdleElementType>}
    */
-  this.typeCache = {};
+  this.typeCache = Object.create(null);
 
   /**
    * @type {Readonly<{readonly strict?: boolean}>}

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -61,12 +61,12 @@ export default function Registry(packages, properties) {
    * @private
    * @type {Record<string, RegisteredPackage>} registered packages map
    */
-  this.packageMap = {};
+  this.packageMap = Object.create(null);
 
   /**
    * @type {Record<string,RegisteredTypeDef>}
    */
-  this.typeMap = {};
+  this.typeMap = Object.create(null);
 
   /**
    * @private
@@ -137,7 +137,7 @@ Registry.prototype.registerType = function(type, pkg) {
 
   var ns = parseNameNs(type.name, pkg.prefix),
       name = ns.name,
-      /** @type {Record<string, RegisteredPropertyDef>} */ propertiesByName = {};
+      /** @type {Record<string, RegisteredPropertyDef>} */ propertiesByName = Object.create(null);
 
   // parse properties
   forEach(type.properties, bind(function(p) {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -132,7 +132,7 @@ Registry.prototype.registerType = function(type, pkg) {
     superClass: (type.superClass || []).slice(),
     extends: (type.extends || []).slice(),
     properties: (type.properties || []).slice(),
-    meta: assign(({}, type.meta || {}))
+    meta: assign({}, type.meta || {})
   });
 
   var ns = parseNameNs(type.name, pkg.prefix),

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,23 +1,23 @@
 /**
  * Built-in moddle types
  */
-var BUILTINS = {
+var BUILTINS = Object.assign(Object.create(null), {
   String: true,
   Boolean: true,
   Integer: true,
   Real: true,
   Element: true
-};
+});
 
 /**
  * Converters for built-in types from string representations
  */
-var TYPE_CONVERTERS = {
+var TYPE_CONVERTERS = Object.assign(Object.create(null), {
   String: function(s) { return s; },
   Boolean: function(s) { return s === 'true'; },
   Integer: function(s) { return parseInt(s, 10); },
   Real: function(s) { return parseFloat(s); }
-};
+});
 
 /**
  * @typedef {'String'} StringType

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,7 +1,11 @@
+import {
+  assign
+} from 'min-dash';
+
 /**
  * Built-in moddle types
  */
-var BUILTINS = Object.assign(Object.create(null), {
+var BUILTINS = assign(Object.create(null), {
   String: true,
   Boolean: true,
   Integer: true,
@@ -12,7 +16,7 @@ var BUILTINS = Object.assign(Object.create(null), {
 /**
  * Converters for built-in types from string representations
  */
-var TYPE_CONVERTERS = Object.assign(Object.create(null), {
+var TYPE_CONVERTERS = assign(Object.create(null), {
   String: function(s) { return s; },
   Boolean: function(s) { return s === 'true'; },
   Integer: function(s) { return parseInt(s, 10); },

--- a/test/spec/meta.js
+++ b/test/spec/meta.js
@@ -4,6 +4,8 @@ import {
   createModelBuilder
 } from '../helper.js';
 
+import { Moddle } from 'moddle';
+
 
 describe('meta', function() {
 
@@ -30,6 +32,31 @@ describe('meta', function() {
     // then
     expect(meta.owners).to.exist;
     expect(meta.owners).to.eql([ 'the pope', 'donald trump' ]);
+  });
+
+
+  it('should copy "meta" from type definition', function() {
+
+    // given
+    var typeMeta = { owners: [ 'the pope' ] };
+
+    var pkg = {
+      name: 'Cars',
+      uri: 'http://cars',
+      prefix: 'c',
+      types: [
+        { name: 'Car', meta: typeMeta }
+      ]
+    };
+
+    // when
+    var registeredModel = new Moddle([ pkg ]);
+
+    // then
+    var meta = registeredModel.getTypeDescriptor('c:Car').meta;
+
+    expect(meta).to.eql(typeMeta);
+    expect(meta).not.to.equal(typeMeta);
   });
 
 });

--- a/test/spec/moddle.js
+++ b/test/spec/moddle.js
@@ -54,6 +54,22 @@ describe('moddle', function() {
     });
 
 
+    it('should NOT return Object properties as package', function() {
+
+      // given
+      var objectProperties = [ 'constructor', 'toString', '__proto__' ];
+
+      for (const property of objectProperties) {
+
+        // when
+        var pkg = model.getPackage(property);
+
+        // then
+        expect(pkg).not.to.exist;
+      }
+    });
+
+
     it('should provide type descriptor', function() {
 
       // given
@@ -359,6 +375,31 @@ describe('moddle', function() {
         expect(simpleBody).to.include.keys([ 'name', 'superClass', 'properties' ]);
       });
 
+
+      it('should NOT resolve Object properties as type / descriptor', function() {
+
+        // given
+        var SimpleBody = model.getType('props:SimpleBody');
+
+        var instance = new SimpleBody();
+
+        var objectProperties = [ 'constructor', 'toString', '__proto__' ];
+
+        for (const property of objectProperties) {
+
+          // then
+          expect(function() {
+            model.getType(property);
+          }, property).to.throw(/unknown type/);
+
+          expect(model.getTypeDescriptor(property), property).not.to.exist;
+
+          expect(model.getPropertyDescriptor(instance, property), property).not.to.exist;
+
+          expect(model.hasType(instance, property), property).to.be.false;
+        }
+      });
+
     });
 
   });
@@ -608,5 +649,4 @@ describe('moddle', function() {
     });
 
   });
-
 });

--- a/test/spec/types.js
+++ b/test/spec/types.js
@@ -1,8 +1,13 @@
 import expect from '../expect.js';
 
 import {
-  coerceType
+  coerceType,
+  isBuiltIn,
+  isSimple
 } from '../../lib/types.js';
+
+
+var OBJECT_PROPERTIES = [ 'constructor', 'toString', '__proto__', 'hasOwnProperty' ];
 
 
 describe('Types', function() {
@@ -37,6 +42,71 @@ describe('Types', function() {
     it('should NOT convert complex', function() {
       var complexElement = { a: 'A' };
       expect(coerceType('Element', complexElement)).to.equal(complexElement);
+    });
+
+
+    it('should NOT convert Object properties', function() {
+
+      for (const property of OBJECT_PROPERTIES) {
+
+        // given
+        var value = { a: 'A' };
+
+        // when
+        // then
+        expect(coerceType(property, value), property).to.equal(value);
+      }
+    });
+
+  });
+
+
+  describe('isBuiltIn', function() {
+
+    it('should recognize built-in types', function() {
+      expect(isBuiltIn('String')).to.be.true;
+      expect(isBuiltIn('Boolean')).to.be.true;
+      expect(isBuiltIn('Integer')).to.be.true;
+      expect(isBuiltIn('Real')).to.be.true;
+      expect(isBuiltIn('Element')).to.be.true;
+    });
+
+
+    it('should NOT recognize custom types', function() {
+      expect(isBuiltIn('props:Complex')).to.be.false;
+    });
+
+
+    it('should NOT recognize Object properties as built-in', function() {
+
+      for (const property of OBJECT_PROPERTIES) {
+        expect(isBuiltIn(property), property).to.be.false;
+      }
+    });
+
+  });
+
+
+  describe('isSimple', function() {
+
+    it('should recognize simple types', function() {
+      expect(isSimple('String')).to.be.true;
+      expect(isSimple('Boolean')).to.be.true;
+      expect(isSimple('Integer')).to.be.true;
+      expect(isSimple('Real')).to.be.true;
+    });
+
+
+    it('should NOT recognize Element as simple', function() {
+      expect(isSimple('Element')).to.be.false;
+    });
+
+
+    it('should NOT recognize Object properties as simple', function() {
+
+      for (const property of OBJECT_PROPERTIES) {
+        expect(isSimple(property), property).to.be.false;
+      }
     });
 
   });


### PR DESCRIPTION
Below is the 🤖 's input. I kicked the PR with a test case which confirmed the bug.


## What

Internal string-keyed lookup maps (packages, types, descriptors, built-ins) were plain object literals inheriting from `Object.prototype`. Keys like `constructor`, `toString`, and `__proto__` resolved inherited members instead of missing, so several lookup APIs returned bogus results for those keys:

- `getPackage('constructor')` → `[Function Object]` instead of `undefined`
- `getType('constructor')` → silently built a descriptor instead of throwing (because `isBuiltIn('constructor')` was truthy via the inherited `Object` constructor)
- `getTypeDescriptor` / `getPropertyDescriptor` / `hasType` similarly polluted

## How

Switch all string-keyed registries to null-prototype maps (`Object.create(null)`), fixing the whole class of bug uniformly at both `map[key]` reads and `key in map` checks, and hardening the write side (`__proto__` can no longer hijack a prototype):

- `lib/registry.js` — `packageMap`, `typeMap`, per-type `propertiesByName`
- `lib/moddle.js` — `typeCache`
- `lib/descriptor-builder.js` — `allTypesByName`, `propertiesByName`
- `lib/types.js` — `BUILTINS`, `TYPE_CONVERTERS`

After the fix `getType('constructor')` correctly throws `unknown type <constructor>` (consistent with existing unknown-type behavior), while the descriptor lookups return `undefined` and `hasType` returns `false`.

## Reviewer notes

The builder's `propertiesByName` / `allTypesByName` flow into the public `EffectiveDescriptor` and are now null-prototype. Bracket-lookup and `Object.keys()` consumers are unaffected; only calling `.hasOwnProperty()` *on the map itself* would break (implausible).

## Tests

Two behavioral tests added covering all three poison keys; full suite green (117 passing), lint clean, `generate-types` + `tsc --noImplicitAny` clean with no `.d.ts` drift.

Related to https://jira.camunda.com/browse/SEC-3064

🤖 Generated with [Claude Code](https://claude.com/claude-code)